### PR TITLE
feat: email campaign engine (#19)

### DIFF
--- a/app/api/campaigns/[id]/retry/route.ts
+++ b/app/api/campaigns/[id]/retry/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+import { verifyToken } from '@/lib/auth-server';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const pubkey = verifyToken(request);
+  if (!pubkey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const { data: job, error: jobError } = await supabase
+      .from('email_jobs')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (jobError || !job) {
+      return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+    }
+
+    if (!['partial', 'failed'].includes(job.status)) {
+      return NextResponse.json(
+        { error: `Cannot retry campaign with status: ${job.status}` },
+        { status: 400 }
+      );
+    }
+
+    // Reset failed sends to pending
+    const { error: resetError } = await supabase
+      .from('email_sends')
+      .update({ status: 'pending', error: null })
+      .eq('job_id', id)
+      .eq('status', 'failed');
+
+    if (resetError) {
+      console.error('Reset sends error:', resetError);
+      return NextResponse.json({ error: 'Failed to reset failed sends' }, { status: 500 });
+    }
+
+    // Reset job for re-processing
+    const { data: campaign, error: updateError } = await supabase
+      .from('email_jobs')
+      .update({
+        status: 'pending',
+        cursor: 0,
+        failed_count: 0,
+        completed_at: null,
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Job reset error:', updateError);
+      return NextResponse.json({ error: 'Failed to reset campaign' }, { status: 500 });
+    }
+
+    return NextResponse.json({ campaign });
+  } catch (error) {
+    console.error('Campaign retry error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+import { verifyToken } from '@/lib/auth-server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const pubkey = verifyToken(request);
+  if (!pubkey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const { data: campaign, error: jobError } = await supabase
+      .from('email_jobs')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (jobError || !campaign) {
+      return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+    }
+
+    const { data: sends, error: sendsError } = await supabase
+      .from('email_sends')
+      .select('*')
+      .eq('job_id', id)
+      .order('created_at');
+
+    if (sendsError) {
+      console.error('Sends fetch error:', sendsError);
+      return NextResponse.json({ error: 'Failed to fetch sends' }, { status: 500 });
+    }
+
+    return NextResponse.json({ campaign, sends: sends || [] });
+  } catch (error) {
+    console.error('Campaign GET error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const pubkey = verifyToken(request);
+  if (!pubkey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await request.json();
+
+    if (body.status !== 'cancelled') {
+      return NextResponse.json({ error: 'Only cancellation is supported' }, { status: 400 });
+    }
+
+    // Check current status
+    const { data: existing, error: fetchError } = await supabase
+      .from('email_jobs')
+      .select('status')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+    }
+
+    const cancellable = ['pending', 'running', 'partial'];
+    if (!cancellable.includes(existing.status)) {
+      return NextResponse.json(
+        { error: `Cannot cancel campaign with status: ${existing.status}` },
+        { status: 400 }
+      );
+    }
+
+    const { data: campaign, error: updateError } = await supabase
+      .from('email_jobs')
+      .update({ status: 'cancelled', completed_at: new Date().toISOString() })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Campaign cancel error:', updateError);
+      return NextResponse.json({ error: 'Failed to cancel campaign' }, { status: 500 });
+    }
+
+    return NextResponse.json({ campaign });
+  } catch (error) {
+    console.error('Campaign PATCH error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/campaigns/[id]/send/route.ts
+++ b/app/api/campaigns/[id]/send/route.ts
@@ -1,0 +1,231 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+import { verifyToken } from '@/lib/auth-server';
+import { sendEmail } from '@/lib/email-sender';
+import { composeEmail } from '@/lib/email-composer';
+import type { EmailIntegration } from '@/lib/types';
+
+const BATCH_SIZE = 10;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const pubkey = verifyToken(request);
+  if (!pubkey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    // 1. Load job
+    const { data: job, error: jobError } = await supabase
+      .from('email_jobs')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (jobError || !job) {
+      return NextResponse.json({ error: 'Campaign not found' }, { status: 404 });
+    }
+
+    if (!['pending', 'partial'].includes(job.status)) {
+      return NextResponse.json(
+        { error: `Cannot send campaign with status: ${job.status}` },
+        { status: 400 }
+      );
+    }
+
+    // 2. Set status to running
+    await supabase
+      .from('email_jobs')
+      .update({ status: 'running', started_at: job.started_at || new Date().toISOString() })
+      .eq('id', id);
+
+    // 3. Load integration
+    const integrationId = (job.config as Record<string, unknown>).integration_id as string;
+    const { data: integration, error: intError } = await supabase
+      .from('email_integrations')
+      .select('*')
+      .eq('id', integrationId)
+      .single();
+
+    if (intError || !integration) {
+      await supabase
+        .from('email_jobs')
+        .update({ status: 'failed', completed_at: new Date().toISOString() })
+        .eq('id', id);
+      return NextResponse.json({ error: 'Email integration not found' }, { status: 400 });
+    }
+
+    // 4. Load template + layout
+    let templateHtml = '';
+    let templateSubject = job.subject;
+    let layoutHtml: string | null = null;
+
+    if (job.template_id) {
+      const { data: template } = await supabase
+        .from('email_templates')
+        .select('*, email_layouts(*)')
+        .eq('id', job.template_id)
+        .single();
+
+      if (template) {
+        templateHtml = template.html_content;
+        templateSubject = job.subject || template.subject;
+        if (template.email_layouts) {
+          layoutHtml = template.email_layouts.html_content;
+        } else if (template.layout_id) {
+          const { data: layout } = await supabase
+            .from('email_layouts')
+            .select('html_content')
+            .eq('id', template.layout_id)
+            .single();
+          if (layout) layoutHtml = layout.html_content;
+        }
+      }
+    }
+
+    // 5. Query pending sends
+    const { data: pendingSends, error: sendsError } = await supabase
+      .from('email_sends')
+      .select('*, attendees!inner(id, name, email)')
+      .eq('job_id', id)
+      .eq('status', 'pending')
+      .order('created_at');
+
+    if (sendsError) {
+      console.error('Sends query error:', sendsError);
+      await supabase
+        .from('email_jobs')
+        .update({ status: 'failed', completed_at: new Date().toISOString() })
+        .eq('id', id);
+      return NextResponse.json({ error: 'Failed to load pending sends' }, { status: 500 });
+    }
+
+    const sends = pendingSends || [];
+    let sentCount = job.sent_count || 0;
+    let failedCount = job.failed_count || 0;
+
+    // 6. Process in batches
+    for (let i = 0; i < sends.length; i += BATCH_SIZE) {
+      // Re-check job status for cancellation
+      const { data: currentJob } = await supabase
+        .from('email_jobs')
+        .select('status')
+        .eq('id', id)
+        .single();
+
+      if (currentJob?.status === 'cancelled') {
+        break;
+      }
+
+      const batch = sends.slice(i, i + BATCH_SIZE);
+
+      for (const send of batch) {
+        const attendee = send.attendees as Record<string, unknown>;
+        const attendeeName = (attendee.name as string) || '';
+        const attendeeEmail = (attendee.email as string) || send.email;
+        const firstName = attendeeName.split(' ')[0] || attendeeName;
+
+        const variables: Record<string, string> = {
+          name: attendeeName,
+          firstname: firstName,
+          first_name: firstName,
+          fullname: attendeeName,
+          email: attendeeEmail,
+          subject: templateSubject,
+        };
+
+        try {
+          const composed = composeEmail({
+            template: { html_content: templateHtml, subject: templateSubject },
+            layout: layoutHtml ? { html_content: layoutHtml } : null,
+            variables,
+          });
+
+          await sendEmail(integration as EmailIntegration, {
+            to: attendeeEmail,
+            subject: composed.subject,
+            html: composed.html,
+          });
+
+          await supabase
+            .from('email_sends')
+            .update({
+              status: 'sent',
+              sent_at: new Date().toISOString(),
+              attempts: (send.attempts || 0) + 1,
+            })
+            .eq('id', send.id);
+
+          sentCount++;
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+
+          await supabase
+            .from('email_sends')
+            .update({
+              status: 'failed',
+              error: errorMsg,
+              attempts: (send.attempts || 0) + 1,
+            })
+            .eq('id', send.id);
+
+          failedCount++;
+        }
+      }
+
+      // Update job progress after each batch
+      await supabase
+        .from('email_jobs')
+        .update({
+          sent_count: sentCount,
+          failed_count: failedCount,
+          cursor: i + batch.length,
+          last_heartbeat: new Date().toISOString(),
+        })
+        .eq('id', id);
+    }
+
+    // 7. Final status
+    const { data: finalCheck } = await supabase
+      .from('email_jobs')
+      .select('status')
+      .eq('id', id)
+      .single();
+
+    let finalStatus: string;
+    if (finalCheck?.status === 'cancelled') {
+      finalStatus = 'cancelled';
+    } else if (failedCount > 0 && sentCount > 0) {
+      finalStatus = 'partial';
+    } else if (failedCount > 0 && sentCount === 0) {
+      finalStatus = 'failed';
+    } else {
+      finalStatus = 'completed';
+    }
+
+    const { data: campaign } = await supabase
+      .from('email_jobs')
+      .update({
+        status: finalStatus,
+        sent_count: sentCount,
+        failed_count: failedCount,
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    return NextResponse.json({ campaign });
+  } catch (error) {
+    console.error('Campaign send error:', error);
+    await supabase
+      .from('email_jobs')
+      .update({ status: 'failed', completed_at: new Date().toISOString() })
+      .eq('id', id);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+import { verifyToken } from '@/lib/auth-server';
+import type { EmailJobSegment } from '@/lib/types';
+
+export async function GET(request: NextRequest) {
+  const pubkey = verifyToken(request);
+  if (!pubkey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const eventId = searchParams.get('event_id');
+
+    if (!eventId) {
+      return NextResponse.json({ error: 'event_id is required' }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('email_jobs')
+      .select('*')
+      .eq('event_id', eventId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Campaigns fetch error:', error);
+      return NextResponse.json({ error: 'Failed to fetch campaigns' }, { status: 500 });
+    }
+
+    return NextResponse.json({ campaigns: data || [] });
+  } catch (error) {
+    console.error('Campaigns GET error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+const VALID_SEGMENTS: EmailJobSegment[] = ['checked-in', 'no-show', 'waitlist'];
+
+export async function POST(request: NextRequest) {
+  const pubkey = verifyToken(request);
+  if (!pubkey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { event_id, segment, template_id, subject, integration_id } = body;
+
+    if (!event_id || !segment || !template_id || !subject || !integration_id) {
+      return NextResponse.json(
+        { error: 'event_id, segment, template_id, subject, and integration_id are required' },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_SEGMENTS.includes(segment)) {
+      return NextResponse.json({ error: 'Invalid segment' }, { status: 400 });
+    }
+
+    // Resolve segment to attendees
+    let query = supabase
+      .from('event_attendees')
+      .select('attendee_id, attendees!inner(id, name, email)')
+      .eq('event_id', event_id);
+
+    switch (segment as EmailJobSegment) {
+      case 'checked-in':
+        query = query.eq('checked_in', true);
+        break;
+      case 'no-show':
+        query = query.eq('status', 'approved').eq('checked_in', false);
+        break;
+      case 'waitlist':
+        query = query.eq('status', 'waitlist');
+        break;
+    }
+
+    const { data: attendeeRows, error: attendeeError } = await query;
+
+    if (attendeeError) {
+      console.error('Attendee query error:', attendeeError);
+      return NextResponse.json({ error: 'Failed to query attendees' }, { status: 500 });
+    }
+
+    const attendees = (attendeeRows || []).map((row: Record<string, unknown>) => {
+      const att = row.attendees as Record<string, unknown>;
+      return {
+        attendee_id: row.attendee_id as number,
+        email: att.email as string,
+      };
+    });
+
+    if (attendees.length === 0) {
+      return NextResponse.json({ error: 'No attendees found for this segment' }, { status: 400 });
+    }
+
+    // Create email job
+    const { data: job, error: jobError } = await supabase
+      .from('email_jobs')
+      .insert({
+        event_id,
+        segment,
+        template_id,
+        subject,
+        status: 'pending',
+        total_contacts: attendees.length,
+        sent_count: 0,
+        failed_count: 0,
+        cursor: 0,
+        errors: [],
+        config: { integration_id },
+        created_by: pubkey,
+      })
+      .select()
+      .single();
+
+    if (jobError || !job) {
+      console.error('Job create error:', jobError);
+      return NextResponse.json({ error: 'Failed to create campaign' }, { status: 500 });
+    }
+
+    // Bulk insert email sends
+    const sends = attendees.map((a: { attendee_id: number; email: string }) => ({
+      job_id: job.id,
+      attendee_id: a.attendee_id,
+      email: a.email,
+      status: 'pending',
+      attempts: 0,
+    }));
+
+    const { error: sendsError } = await supabase.from('email_sends').insert(sends);
+
+    if (sendsError) {
+      console.error('Sends insert error:', sendsError);
+      // Clean up the job
+      await supabase.from('email_jobs').delete().eq('id', job.id);
+      return NextResponse.json({ error: 'Failed to create email sends' }, { status: 500 });
+    }
+
+    return NextResponse.json({ campaign: job }, { status: 201 });
+  } catch (error) {
+    console.error('Campaigns POST error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/email-integrations/[id]/test/route.ts
+++ b/app/api/email-integrations/[id]/test/route.ts
@@ -1,16 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
 import { verifyToken } from '@/lib/auth-server';
-import nodemailer from 'nodemailer';
-import { promises as dnsPromises } from 'dns';
-import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
-import type { SmtpConfig, AwsSesConfig, ResendConfig } from '@/lib/types';
+import { sendEmail } from '@/lib/email-sender';
 import { composeEmail } from '@/lib/email-composer';
-
-async function resolveIPv4(hostname: string): Promise<string> {
-  const { address } = await dnsPromises.lookup(hostname, { family: 4 });
-  return address;
-}
 
 export async function POST(
   request: NextRequest,
@@ -39,7 +31,6 @@ export async function POST(
       return NextResponse.json({ error: 'Integration not found' }, { status: 404 });
     }
 
-    const config = JSON.parse(integration.config);
     const testContent = `<h2>Test Email</h2><p>This is a test email sent from the <strong>${integration.name}</strong> integration.</p><p>If you received this, your email configuration is working correctly.</p>`;
 
     let subject = `Test email from ${integration.name}`;
@@ -64,75 +55,7 @@ export async function POST(
       }
     }
 
-    switch (integration.type) {
-      case 'smtp': {
-        const cfg = config as SmtpConfig;
-        const ip = await resolveIPv4(cfg.host);
-        // Port 465 uses implicit TLS; other ports (587, 25) use STARTTLS
-        const secure = cfg.port === 465;
-        const transport = nodemailer.createTransport({
-          host: ip,
-          port: cfg.port,
-          secure,
-          auth: { user: cfg.username, pass: cfg.password },
-          tls: { servername: cfg.host },
-        });
-        await transport.sendMail({
-          from: cfg.from_email,
-          to,
-          subject,
-          html,
-        });
-        break;
-      }
-
-      case 'aws_ses': {
-        const cfg = config as AwsSesConfig;
-        const ses = new SESClient({
-          region: cfg.region,
-          credentials: {
-            accessKeyId: cfg.access_key_id,
-            secretAccessKey: cfg.secret_access_key,
-          },
-        });
-        await ses.send(
-          new SendEmailCommand({
-            Source: cfg.from_email,
-            Destination: { ToAddresses: [to] },
-            Message: {
-              Subject: { Data: subject },
-              Body: { Html: { Data: html } },
-            },
-          })
-        );
-        break;
-      }
-
-      case 'resend': {
-        const cfg = config as ResendConfig;
-        const res = await fetch('https://api.resend.com/emails', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${cfg.api_key}`,
-          },
-          body: JSON.stringify({
-            from: cfg.from_email,
-            to,
-            subject,
-            html,
-          }),
-        });
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          throw new Error(body.message || `Resend API error: ${res.status}`);
-        }
-        break;
-      }
-
-      default:
-        return NextResponse.json({ error: `Unsupported integration type: ${integration.type}` }, { status: 400 });
-    }
+    await sendEmail(integration, { to, subject, html });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/components/CampaignCreateDialog.tsx
+++ b/components/CampaignCreateDialog.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useTemplates } from "@/hooks/useTemplates";
+import { useEmailIntegrations } from "@/hooks/useEmailIntegrations";
+import type { EmailJobSegment } from "@/lib/types";
+
+const SEGMENT_OPTIONS: { value: EmailJobSegment; label: string }[] = [
+  { value: "checked-in", label: "Checked In" },
+  { value: "no-show", label: "No Show" },
+  { value: "waitlist", label: "Waitlist" },
+];
+
+interface CampaignCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  eventId: string;
+  onSubmit: (params: {
+    event_id: string;
+    segment: EmailJobSegment;
+    template_id: string;
+    subject: string;
+    integration_id: string;
+  }) => Promise<void>;
+}
+
+export function CampaignCreateDialog({
+  open,
+  onOpenChange,
+  eventId,
+  onSubmit,
+}: CampaignCreateDialogProps) {
+  const [segment, setSegment] = useState<EmailJobSegment | "">("");
+  const [templateId, setTemplateId] = useState("");
+  const [subject, setSubject] = useState("");
+  const [integrationId, setIntegrationId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { templates } = useTemplates(
+    segment ? { segment: segment as EmailJobSegment } : undefined
+  );
+  const { integrations } = useEmailIntegrations();
+
+  // Pre-fill subject when template changes
+  useEffect(() => {
+    if (templateId) {
+      const tmpl = templates.find((t) => t.id === templateId);
+      if (tmpl) setSubject(tmpl.subject);
+    }
+  }, [templateId, templates]);
+
+  // Pre-select default integration
+  useEffect(() => {
+    if (integrations.length > 0 && !integrationId) {
+      const defaultInt = integrations.find((i) => i.is_default);
+      setIntegrationId(defaultInt?.id || integrations[0].id);
+    }
+  }, [integrations, integrationId]);
+
+  // Reset form when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSegment("");
+      setTemplateId("");
+      setSubject("");
+      setIntegrationId("");
+      setError(null);
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!segment || !templateId || !subject || !integrationId) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await onSubmit({
+        event_id: eventId,
+        segment: segment as EmailJobSegment,
+        template_id: templateId,
+        subject,
+        integration_id: integrationId,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create campaign");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isValid = segment && templateId && subject.trim() && integrationId;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New Campaign</DialogTitle>
+          <DialogDescription>
+            Send an email campaign to a segment of attendees.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Segment */}
+          <div className="space-y-2">
+            <Label>Segment</Label>
+            <Select
+              value={segment}
+              onValueChange={(v) => {
+                setSegment(v as EmailJobSegment);
+                setTemplateId("");
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select segment..." />
+              </SelectTrigger>
+              <SelectContent>
+                {SEGMENT_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Template */}
+          <div className="space-y-2">
+            <Label>Template</Label>
+            <Select
+              value={templateId}
+              onValueChange={setTemplateId}
+              disabled={!segment}
+            >
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    !segment
+                      ? "Select segment first"
+                      : templates.length === 0
+                        ? "No templates for this segment"
+                        : "Select template..."
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {templates.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Subject */}
+          <div className="space-y-2">
+            <Label>Subject</Label>
+            <Input
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Email subject line..."
+            />
+          </div>
+
+          {/* Integration */}
+          <div className="space-y-2">
+            <Label>Email Provider</Label>
+            <Select value={integrationId} onValueChange={setIntegrationId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select provider..." />
+              </SelectTrigger>
+              <SelectContent>
+                {integrations.map((i) => (
+                  <SelectItem key={i.id} value={i.id}>
+                    {i.name} ({i.type})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!isValid || submitting}
+          >
+            {submitting ? "Creating..." : "Create Campaign"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/CampaignProgress.tsx
+++ b/components/CampaignProgress.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { EmailJob } from "@/lib/types";
+
+interface CampaignProgressProps {
+  campaign: EmailJob;
+  onCancel: (id: string) => void;
+  onRefresh: () => void;
+}
+
+export function CampaignProgress({
+  campaign,
+  onCancel,
+  onRefresh,
+}: CampaignProgressProps) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (campaign.status === "running") {
+      intervalRef.current = setInterval(onRefresh, 2000);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [campaign.status, onRefresh]);
+
+  const processed = campaign.sent_count + campaign.failed_count;
+  const total = campaign.total_contacts;
+  const pct = total > 0 ? Math.round((processed / total) * 100) : 0;
+  const remaining = total - processed;
+
+  return (
+    <Card className="p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Sending Campaign</h3>
+          <Badge variant="secondary" className="bg-blue-500/20 text-blue-400 text-xs">
+            {campaign.status}
+          </Badge>
+        </div>
+        {campaign.status === "running" && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onCancel(campaign.id)}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+
+      <Progress value={pct} className="h-2" />
+
+      <div className="flex gap-4 text-xs text-muted-foreground">
+        <span className="text-green-400">Sent: {campaign.sent_count}</span>
+        {campaign.failed_count > 0 && (
+          <span className="text-red-400">Failed: {campaign.failed_count}</span>
+        )}
+        <span>Remaining: {remaining}</span>
+        <span className="ml-auto">{pct}%</span>
+      </div>
+    </Card>
+  );
+}

--- a/components/CampaignResults.tsx
+++ b/components/CampaignResults.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { EmailJob, EmailSend } from "@/lib/types";
+
+interface CampaignResultsProps {
+  campaign: EmailJob;
+  sends: EmailSend[];
+  onRetry?: (id: string) => void;
+}
+
+const statusBadge: Record<string, { className: string; label: string }> = {
+  sent: { className: "bg-green-500/20 text-green-400", label: "Sent" },
+  failed: { className: "bg-red-500/20 text-red-400", label: "Failed" },
+  pending: { className: "bg-muted-foreground/20 text-muted-foreground", label: "Pending" },
+  bounced: { className: "bg-orange-500/20 text-orange-400", label: "Bounced" },
+};
+
+export function CampaignResults({ campaign, sends, onRetry }: CampaignResultsProps) {
+  return (
+    <div className="space-y-4">
+      {/* Summary stats */}
+      <div className="flex gap-4 text-sm">
+        <span className="text-green-400">
+          Sent: {campaign.sent_count}
+        </span>
+        <span className="text-red-400">
+          Failed: {campaign.failed_count}
+        </span>
+        <span className="text-muted-foreground">
+          Total: {campaign.total_contacts}
+        </span>
+        {onRetry && campaign.failed_count > 0 && ["partial", "failed"].includes(campaign.status) && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="ml-auto"
+            onClick={() => onRetry(campaign.id)}
+          >
+            Retry Failed
+          </Button>
+        )}
+      </div>
+
+      {/* Sends table */}
+      {sends.length > 0 && (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Error</TableHead>
+                <TableHead>Sent At</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sends.map((send) => {
+                const badge = statusBadge[send.status] || statusBadge.pending;
+                return (
+                  <TableRow key={send.id}>
+                    <TableCell className="font-mono text-xs">
+                      {send.email}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={`text-xs ${badge.className}`}
+                      >
+                        {badge.label}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground max-w-[200px] truncate">
+                      {send.error || "—"}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {send.sent_at
+                        ? new Date(send.sent_at).toLocaleString()
+                        : "—"}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/CampaignTab.tsx
+++ b/components/CampaignTab.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CampaignCreateDialog } from "./CampaignCreateDialog";
+import { CampaignProgress } from "./CampaignProgress";
+import { CampaignResults } from "./CampaignResults";
+import { useCampaigns, useCampaignDetail } from "@/hooks/useCampaigns";
+import type { EmailJob, EmailJobSegment } from "@/lib/types";
+
+const segmentLabel: Record<EmailJobSegment, string> = {
+  "checked-in": "Checked In",
+  "no-show": "No Show",
+  waitlist: "Waitlist",
+  custom: "Custom",
+};
+
+const statusColor: Record<string, string> = {
+  pending: "bg-muted-foreground/20 text-muted-foreground",
+  running: "bg-blue-500/20 text-blue-400",
+  partial: "bg-orange-500/20 text-orange-400",
+  completed: "bg-green-500/20 text-green-400",
+  failed: "bg-red-500/20 text-red-400",
+  cancelled: "bg-muted-foreground/20 text-muted-foreground",
+};
+
+interface CampaignTabProps {
+  eventId: string;
+}
+
+export function CampaignTab({ eventId }: CampaignTabProps) {
+  const {
+    campaigns,
+    loading,
+    refetch,
+    createCampaign,
+    cancelCampaign,
+    sendCampaign,
+    retryCampaign,
+  } = useCampaigns(eventId);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [sendingId, setSendingId] = useState<string | null>(null);
+
+  const activeCampaign = campaigns.find((c) => c.status === "running");
+  const detailId = expandedId || activeCampaign?.id || null;
+  const { campaign: detailCampaign, sends, refetch: refetchDetail } = useCampaignDetail(detailId);
+
+  const handleCreate = async (params: {
+    event_id: string;
+    segment: EmailJobSegment;
+    template_id: string;
+    subject: string;
+    integration_id: string;
+  }) => {
+    const campaign = await createCampaign(params);
+    // Auto-send after creation
+    setSendingId(campaign.id);
+    try {
+      await sendCampaign(campaign.id);
+    } finally {
+      setSendingId(null);
+    }
+  };
+
+  const handleCancel = async (id: string) => {
+    await cancelCampaign(id);
+    refetchDetail();
+  };
+
+  const handleRetry = async (id: string) => {
+    await retryCampaign(id);
+    // Auto-send after retry
+    setSendingId(id);
+    try {
+      await sendCampaign(id);
+    } finally {
+      setSendingId(null);
+    }
+  };
+
+  const handleRefreshDetail = useCallback(() => {
+    refetchDetail();
+    refetch();
+  }, [refetchDetail, refetch]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Campaigns</h2>
+        <Button onClick={() => setCreateOpen(true)} disabled={!!activeCampaign || !!sendingId}>
+          New Campaign
+        </Button>
+      </div>
+
+      {/* Active campaign progress */}
+      {activeCampaign && detailCampaign && detailCampaign.status === "running" && (
+        <CampaignProgress
+          campaign={detailCampaign}
+          onCancel={handleCancel}
+          onRefresh={handleRefreshDetail}
+        />
+      )}
+
+      {/* Sending indicator for non-running states */}
+      {sendingId && !activeCampaign && (
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Starting campaign...</p>
+        </Card>
+      )}
+
+      {/* Campaign history */}
+      {campaigns.length === 0 ? (
+        <Card className="p-6 text-center text-muted-foreground text-sm">
+          No campaigns yet. Create one to send emails to your attendees.
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {campaigns.map((campaign) => (
+            <CampaignHistoryRow
+              key={campaign.id}
+              campaign={campaign}
+              expanded={expandedId === campaign.id}
+              onToggle={() =>
+                setExpandedId(expandedId === campaign.id ? null : campaign.id)
+              }
+              sends={expandedId === campaign.id ? sends : []}
+              onRetry={handleRetry}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Create dialog */}
+      <CampaignCreateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        eventId={eventId}
+        onSubmit={handleCreate}
+      />
+    </div>
+  );
+}
+
+function CampaignHistoryRow({
+  campaign,
+  expanded,
+  onToggle,
+  sends,
+  onRetry,
+}: {
+  campaign: EmailJob;
+  expanded: boolean;
+  onToggle: () => void;
+  sends: import("@/lib/types").EmailSend[];
+  onRetry: (id: string) => void;
+}) {
+  return (
+    <Card className="overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="w-full p-4 flex items-center gap-3 text-left hover:bg-muted/50 transition-colors"
+      >
+        <Badge
+          variant="secondary"
+          className={`text-xs shrink-0 ${statusColor[campaign.status] || ""}`}
+        >
+          {campaign.status}
+        </Badge>
+        <Badge variant="outline" className="text-xs shrink-0">
+          {segmentLabel[campaign.segment] || campaign.segment}
+        </Badge>
+        <span className="text-sm truncate flex-1">{campaign.subject}</span>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {campaign.sent_count}/{campaign.total_contacts}
+        </span>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {new Date(campaign.created_at).toLocaleDateString()}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="border-t p-4">
+          <CampaignResults
+            campaign={campaign}
+            sends={sends}
+            onRetry={onRetry}
+          />
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/components/EventDetail.tsx
+++ b/components/EventDetail.tsx
@@ -13,6 +13,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CampaignTab } from "./CampaignTab";
 import { cn } from "@/lib/utils";
 
 interface EventDetailProps {
@@ -181,29 +183,42 @@ export function EventDetail({ eventId }: EventDetailProps) {
 
       <StatsBar stats={stats} loading={attendeesLoading} />
 
-      {/* Attendees table */}
-      <Card className="p-6">
-        <h2 className="text-lg font-semibold mb-4">Attendees</h2>
-        {attendeesLoading ? (
-          <div className="space-y-4">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex gap-4">
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-40" />
-                <Skeleton className="h-5 w-16 rounded-full" />
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-4 w-24" />
+      {/* Tabs: Attendees + Campaigns */}
+      <Tabs defaultValue="attendees">
+        <TabsList>
+          <TabsTrigger value="attendees">Attendees</TabsTrigger>
+          <TabsTrigger value="campaigns">Campaigns</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="attendees">
+          <Card className="p-6">
+            <h2 className="text-lg font-semibold mb-4">Attendees</h2>
+            {attendeesLoading ? (
+              <div className="space-y-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div key={i} className="flex gap-4">
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        ) : (
-          <ContactsTable
-            contacts={contactsFromAttendees}
-            onUpdateContact={handleUpdateContact}
-            eventId={eventId}
-          />
-        )}
-      </Card>
+            ) : (
+              <ContactsTable
+                contacts={contactsFromAttendees}
+                onUpdateContact={handleUpdateContact}
+                eventId={eventId}
+              />
+            )}
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="campaigns">
+          <CampaignTab eventId={eventId} />
+        </TabsContent>
+      </Tabs>
 
       {editing && (
         <EventForm

--- a/hooks/useCampaigns.ts
+++ b/hooks/useCampaigns.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { getToken } from '../lib/auth';
+import type { EmailJob, EmailSend, EmailJobSegment } from '../lib/types';
+
+export function useCampaigns(eventId: string) {
+  const [campaigns, setCampaigns] = useState<EmailJob[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCampaigns = useCallback(async () => {
+    const token = getToken();
+    if (!token || !eventId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/campaigns?event_id=${eventId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) throw new Error('Failed to fetch campaigns');
+
+      const data = await response.json();
+      setCampaigns(data.campaigns || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch campaigns');
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchCampaigns();
+  }, [fetchCampaigns]);
+
+  const createCampaign = async (params: {
+    event_id: string;
+    segment: EmailJobSegment;
+    template_id: string;
+    subject: string;
+    integration_id: string;
+  }) => {
+    const token = getToken();
+    if (!token) throw new Error('Not authenticated');
+
+    const response = await fetch('/api/campaigns', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(params),
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json();
+      throw new Error(error || 'Failed to create campaign');
+    }
+
+    const data = await response.json();
+    await fetchCampaigns();
+    return data.campaign as EmailJob;
+  };
+
+  const cancelCampaign = async (campaignId: string) => {
+    const token = getToken();
+    if (!token) throw new Error('Not authenticated');
+
+    const response = await fetch(`/api/campaigns/${campaignId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: 'cancelled' }),
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json();
+      throw new Error(error || 'Failed to cancel campaign');
+    }
+
+    await fetchCampaigns();
+  };
+
+  const sendCampaign = async (campaignId: string) => {
+    const token = getToken();
+    if (!token) throw new Error('Not authenticated');
+
+    const response = await fetch(`/api/campaigns/${campaignId}/send`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json();
+      throw new Error(error || 'Failed to send campaign');
+    }
+
+    await fetchCampaigns();
+    return (await response.json()).campaign as EmailJob;
+  };
+
+  const retryCampaign = async (campaignId: string) => {
+    const token = getToken();
+    if (!token) throw new Error('Not authenticated');
+
+    const response = await fetch(`/api/campaigns/${campaignId}/retry`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json();
+      throw new Error(error || 'Failed to retry campaign');
+    }
+
+    await fetchCampaigns();
+  };
+
+  return { campaigns, loading, error, refetch: fetchCampaigns, createCampaign, cancelCampaign, sendCampaign, retryCampaign };
+}
+
+export function useCampaignDetail(campaignId: string | null) {
+  const [campaign, setCampaign] = useState<EmailJob | null>(null);
+  const [sends, setSends] = useState<EmailSend[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async () => {
+    const token = getToken();
+    if (!token || !campaignId) {
+      setCampaign(null);
+      setSends([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/campaigns/${campaignId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) throw new Error('Failed to fetch campaign detail');
+
+      const data = await response.json();
+      setCampaign(data.campaign || null);
+      setSends(data.sends || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch campaign detail');
+    } finally {
+      setLoading(false);
+    }
+  }, [campaignId]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  return { campaign, sends, loading, error, refetch: fetchDetail };
+}

--- a/hooks/useEmailIntegrations.ts
+++ b/hooks/useEmailIntegrations.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { getToken } from '../lib/auth';
+import type { EmailIntegration } from '../lib/types';
+
+export function useEmailIntegrations() {
+  const [integrations, setIntegrations] = useState<EmailIntegration[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchIntegrations = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      setError('Not authenticated');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/email-integrations', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) throw new Error('Failed to fetch integrations');
+
+      const data = await response.json();
+      setIntegrations(data.integrations || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch integrations');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchIntegrations();
+  }, [fetchIntegrations]);
+
+  return { integrations, loading, error, refetch: fetchIntegrations };
+}

--- a/lib/email-sender.ts
+++ b/lib/email-sender.ts
@@ -1,0 +1,86 @@
+import nodemailer from 'nodemailer';
+import { promises as dnsPromises } from 'dns';
+import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
+import type { EmailIntegration, SmtpConfig, AwsSesConfig, ResendConfig } from './types';
+
+async function resolveIPv4(hostname: string): Promise<string> {
+  const { address } = await dnsPromises.lookup(hostname, { family: 4 });
+  return address;
+}
+
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+/**
+ * Sends an email using the provided integration (SMTP, AWS SES, or Resend).
+ * Throws on failure with a descriptive error message.
+ */
+export async function sendEmail(
+  integration: EmailIntegration,
+  options: SendEmailOptions
+): Promise<void> {
+  const config = JSON.parse(integration.config);
+  const { to, subject, html } = options;
+
+  switch (integration.type) {
+    case 'smtp': {
+      const cfg = config as SmtpConfig;
+      const ip = await resolveIPv4(cfg.host);
+      const secure = cfg.port === 465;
+      const transport = nodemailer.createTransport({
+        host: ip,
+        port: cfg.port,
+        secure,
+        auth: { user: cfg.username, pass: cfg.password },
+        tls: { servername: cfg.host },
+      });
+      await transport.sendMail({ from: cfg.from_email, to, subject, html });
+      break;
+    }
+
+    case 'aws_ses': {
+      const cfg = config as AwsSesConfig;
+      const ses = new SESClient({
+        region: cfg.region,
+        credentials: {
+          accessKeyId: cfg.access_key_id,
+          secretAccessKey: cfg.secret_access_key,
+        },
+      });
+      await ses.send(
+        new SendEmailCommand({
+          Source: cfg.from_email,
+          Destination: { ToAddresses: [to] },
+          Message: {
+            Subject: { Data: subject },
+            Body: { Html: { Data: html } },
+          },
+        })
+      );
+      break;
+    }
+
+    case 'resend': {
+      const cfg = config as ResendConfig;
+      const res = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${cfg.api_key}`,
+        },
+        body: JSON.stringify({ from: cfg.from_email, to, subject, html }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || `Resend API error: ${res.status}`);
+      }
+      break;
+    }
+
+    default:
+      throw new Error(`Unsupported integration type: ${integration.type}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Extract shared `lib/email-sender.ts` utility (SMTP, AWS SES, Resend) from test endpoint
- Add campaign API routes: create, list, detail, send (batched), cancel, retry
- Add `useCampaigns` and `useEmailIntegrations` hooks
- Build campaign UI: creation dialog, real-time progress bar, results table, campaign history
- Integrate into EventDetail via Attendees/Campaigns tabs

Closes #19 (Phase 2)

## Test plan

- [ ] Create a campaign selecting a segment, template, and email provider
- [ ] Verify `email_jobs` + `email_sends` rows are created in DB
- [ ] Send campaign and verify emails arrive, progress bar updates in real-time
- [ ] Cancel a running campaign and verify it stops
- [ ] Retry failed sends and verify only failed ones are re-processed
- [ ] `pnpm build` passes with zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email campaign management: Create, send, cancel, and retry email campaigns to event attendees
  * Real-time campaign progress tracking with sent/failed/remaining counts
  * Campaign results view with individual email statuses and error details
  * Support for multiple email providers (SMTP, AWS SES, Resend)
  * Campaigns tab in event details for comprehensive campaign history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->